### PR TITLE
Changing groupname, converting urls to convexengineering git.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,9 +6,9 @@ highlighter:      rouge
 permalink:        /posts/:year/:title
 
 # Setup
-title:            Hoburg Research Group
-description:      "part of the Department of Aeronautics and Astronautics at MIT"
-url:              http://hoburg.mit.edu
+title:            Convex Engineering Group
+description:      "part of the Aerospace Computational Design Lab at MIT"
+url:              http://convexengineering.mit.edu
 baseurl:
 
 paginate:         5

--- a/projects.md
+++ b/projects.md
@@ -5,7 +5,7 @@ title: Projects
 
 <br>
 <img src="public/images/projects/gplogo.png" width="150px" alt="GPkit">
-[Code](https://www.github.com/hoburg/gpkit) |
+[Code](https://www.github.com/convexengineering/gpkit) |
 [Documentation](https://gpkit.rtfd.org)
 
 GPkit is a Python package for defining and manipulating geometric programming (GP) models.
@@ -27,7 +27,7 @@ _2016-08-05 [Future X-Plane](posts/2016/nasa-d8-green-aviation)_
 
 
 ### Jungle Hawk Owl
-[Code](https://www.github.com/hoburg/jho)
+[Code](https://www.github.com/convexengineering/jho)
 
 <img src="public/images/jho_takeoff.jpg" alt="jho_takeoff" style="width: 700px;"/>
 


### PR DESCRIPTION
@bqpd thought we could pull the trigger on changing the group name and url for the website? However I haven't been able to get the sidebar to change as I intended locally. Lmk if this branch works for you. 